### PR TITLE
GE-1008: Validate data against schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/swagger_server/controllers/user_data_controller.py
+++ b/swagger_server/controllers/user_data_controller.py
@@ -264,6 +264,12 @@ def usersitedata_create(data=None):  # noqa: E501
     if connexion.request.is_json:
         data = connexion.request.get_json()
 
+    # Get site data schema
+    schema = sitedataschema_read(data["site_id"]).schema
+
+    # Check data schema first
+    util.validate_schema(data["data"], schema)
+
     return db_actions.crud(
         model="UserSiteData",
         api_model=UserSiteData,
@@ -367,6 +373,12 @@ def usersitedata_update(user_id, site_id, data=None):  # noqa: E501
     """
     if connexion.request.is_json:
         data = connexion.request.get_json()
+
+    # Get site data schema
+    schema = sitedataschema_read(site_id).schema
+
+    # Check data schema first
+    util.validate_schema(data["data"], schema)
 
     return db_actions.crud(
         model="UserSiteData",

--- a/swagger_server/test/test_user_data_controller.py
+++ b/swagger_server/test/test_user_data_controller.py
@@ -59,7 +59,6 @@ class TestUserDataController(BaseTestCase):
         )
 
         self.usersitedata_data = {
-            # TODO: not what I did here
             "site_id": random.randint(2, 2000000),
             "user_id": "%s" % uuid.uuid1(),
             "data": {"test": "data"},
@@ -241,7 +240,6 @@ class TestUserDataController(BaseTestCase):
 
         """
         data = SiteDataSchemaCreate(**{
-            # TODO: not what I did here
             "site_id": random.randint(2, 2000000),
             "schema": {"test": "data"}
         })
@@ -376,7 +374,6 @@ class TestUserDataController(BaseTestCase):
 
         """
         data = UserSiteDataCreate(**{
-            # TODO: not what I did here
             "site_id": self.sitedataschema_data["site_id"],
             "user_id": "%s" % uuid.uuid1(),
             "data": {"item_1": 1, "item_2": 2},
@@ -394,7 +391,6 @@ class TestUserDataController(BaseTestCase):
         self.assertEquals(response.status_code, 400)
 
         data = UserSiteDataCreate(**{
-            # TODO: not what I did here
             "site_id": self.sitedataschema_data["site_id"],
             "user_id": "%s" % uuid.uuid1(),
             "data": {"item_1": 1, "item_2": "a string"},
@@ -421,7 +417,6 @@ class TestUserDataController(BaseTestCase):
 
         """
         data = {
-            # TODO: not what I did here
             "site_id": random.randint(2, 2000000),
             "user_id": "%s" % uuid.uuid1(),
             "data": {"test": "delete this data"},
@@ -497,7 +492,6 @@ class TestUserDataController(BaseTestCase):
 
         """
         data = {
-            # TODO: not what I did here
             "site_id": self.sitedataschema_data["site_id"],
             "user_id": "%s" % uuid.uuid1(),
             "data": {"test": "data"},

--- a/swagger_server/test/test_user_data_controller.py
+++ b/swagger_server/test/test_user_data_controller.py
@@ -48,7 +48,7 @@ class TestUserDataController(BaseTestCase):
                     "item_1": {"type": "number"},
                     "item_2": {"type": "string"}
                 },
-                "required": ["item_1", "item_2"]
+                "additionalProperties": False
             }
         }
         self.sitedataschema_model = db_actions.crud(
@@ -389,6 +389,10 @@ class TestUserDataController(BaseTestCase):
 
         # Response should contain bad request
         self.assertEquals(response.status_code, 400)
+        json_data = json.loads(response.data)
+        self.assertIn(
+            "Data does not match expected schema:2 is not of type 'string'",
+            json_data["detail"])
 
         data = UserSiteDataCreate(**{
             "site_id": self.sitedataschema_data["site_id"],
@@ -521,9 +525,12 @@ class TestUserDataController(BaseTestCase):
 
         # Check for bad request
         self.assertEqual(response.status_code, 400)
+        json_data = json.loads(response.data)
+        self.assertIn(
+            "Data does not match expected schema:Additional properties are not "
+            "allowed ('test' was unexpected)", json_data["detail"])
 
         # Retry with correct data
-
         data = {"data": {"item_1": 1, "item_2": "another string"}}
 
         data = UserSiteDataUpdate(**data)

--- a/swagger_server/test/test_user_data_controller.py
+++ b/swagger_server/test/test_user_data_controller.py
@@ -42,7 +42,14 @@ class TestUserDataController(BaseTestCase):
 
         self.sitedataschema_data = {
             "site_id": random.randint(2, 2000000),
-            "schema": {"test": "data"}
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "item_1": {"type": "number"},
+                    "item_2": {"type": "string"}
+                },
+                "required": ["item_1", "item_2"]
+            }
         }
         self.sitedataschema_model = db_actions.crud(
             model="SiteDataSchema",
@@ -370,9 +377,27 @@ class TestUserDataController(BaseTestCase):
         """
         data = UserSiteDataCreate(**{
             # TODO: not what I did here
-            "site_id": random.randint(2, 2000000),
+            "site_id": self.sitedataschema_data["site_id"],
             "user_id": "%s" % uuid.uuid1(),
-            "data": {"test": "data"},
+            "data": {"item_1": 1, "item_2": 2},
+            "consented_at": datetime.utcnow(),
+            "blocked": False
+        })
+        response = self.client.open(
+            "/api/v1/usersitedata",
+            method="POST",
+            data=json.dumps(data),
+            content_type="application/json",
+            headers=self.headers)
+
+        # Response should contain bad request
+        self.assertEquals(response.status_code, 400)
+
+        data = UserSiteDataCreate(**{
+            # TODO: not what I did here
+            "site_id": self.sitedataschema_data["site_id"],
+            "user_id": "%s" % uuid.uuid1(),
+            "data": {"item_1": 1, "item_2": "a string"},
             "consented_at": datetime.utcnow(),
             "blocked": False
         })
@@ -473,7 +498,7 @@ class TestUserDataController(BaseTestCase):
         """
         data = {
             # TODO: not what I did here
-            "site_id": random.randint(2, 2000000),
+            "site_id": self.sitedataschema_data["site_id"],
             "user_id": "%s" % uuid.uuid1(),
             "data": {"test": "data"},
             "consented_at": datetime.utcnow(),
@@ -499,6 +524,25 @@ class TestUserDataController(BaseTestCase):
             data=json.dumps(data),
             content_type='application/json',
             headers=self.headers)
+
+        # Check for bad request
+        self.assertEqual(response.status_code, 400)
+
+        # Retry with correct data
+
+        data = {"data": {"item_1": 1, "item_2": "another string"}}
+
+        data = UserSiteDataUpdate(**data)
+
+        response = self.client.open(
+            '/api/v1/usersitedata/{user_id}/{site_id}'.format(
+                user_id=model.user_id,
+                site_id=model.site_id),
+            method='PUT',
+            data=json.dumps(data),
+            content_type='application/json',
+            headers=self.headers)
+
         response_data = json.loads(response.data)
 
         updated_entry = db_actions.crud(

--- a/swagger_server/util.py
+++ b/swagger_server/util.py
@@ -145,7 +145,13 @@ def _deserialize_dict(data, boxed_type):
 
 
 def validate_schema(data, schema):
+    """This function validates the data from a UserSiteData object against the
+    schema from a SiteDataSchema object.
+    :param data: dict from UserSiteData object's data field.
+    :param schema: dict from SiteDataSchema object's schema field.
+    """
     try:
         validate(data, schema)
     except Exception:
-        raise BadRequest()
+        raise BadRequest(
+            "Data does not match expected schema:{}".format(schema))

--- a/swagger_server/util.py
+++ b/swagger_server/util.py
@@ -3,6 +3,9 @@ import datetime
 import six
 import typing
 
+from jsonschema import validate
+from werkzeug.exceptions import BadRequest
+
 
 def _deserialize(data, klass):
     """Deserializes dict, list, str into an object.
@@ -139,3 +142,10 @@ def _deserialize_dict(data, boxed_type):
     """
     return {k: _deserialize(v, boxed_type)
             for k, v in six.iteritems(data)}
+
+
+def validate_schema(data, schema):
+    try:
+        validate(data, schema)
+    except Exception:
+        raise BadRequest()

--- a/swagger_server/util.py
+++ b/swagger_server/util.py
@@ -3,7 +3,7 @@ import datetime
 import six
 import typing
 
-from jsonschema import validate
+from jsonschema import validate, ValidationError
 from werkzeug.exceptions import BadRequest
 
 
@@ -152,6 +152,6 @@ def validate_schema(data, schema):
     """
     try:
         validate(data, schema)
-    except Exception:
+    except ValidationError as e:
         raise BadRequest(
-            "Data does not match expected schema:{}".format(schema))
+            f"Data does not match expected schema:{e.message}")


### PR DESCRIPTION
The data in a UserSiteData object should be validated against the schema in a SiteDataSchema.

In this PR:
- Validation takes place on UserSiteData create and update methods.
- Validation utility created to perform validation.
- Tests are updated to check validation.

## **An important note about the validation**
If you have a schema:
```
{
    "type": "object", 
    "properties": {
        "item_1": {"type": "number"},
        "item_2": {"type": "string"}
    },
}
```
but don't include any required fields, data such as ```{"data": "test"}``` will still validate.